### PR TITLE
Prevent the bot from replying multiple text messages

### DIFF
--- a/cogs/messagehandler.py
+++ b/cogs/messagehandler.py
@@ -249,17 +249,18 @@ class ListenerCog(commands.Cog, name="listener"):
                 message,
             )
             await self.add_message_to_dict(message, message.clean_content)
-            async with message.channel.typing():
-                # If the response is more than 2000 characters, split it
-                chunks = [response[i : i + 1998] for i in range(0, len(response), 1998)]
-                for chunk in chunks:
-                    print(chunk)
-                    response_obj = await message.channel.send(chunk)
-                    await self.add_message_to_dict(
-                        response_obj, response_obj.clean_content
-                    )
-                    # self.bot.sent_last_message[str(message.channel.id)] = True
-                    # await log_message(response_obj)
+            if response:
+                async with message.channel.typing():
+                    # If the response is more than 2000 characters, split it
+                    chunks = [response[i : i + 1998] for i in range(0, len(response), 1998)]
+                    for chunk in chunks:
+                        print(chunk)
+                        response_obj = await message.channel.send(chunk)
+                        await self.add_message_to_dict(
+                            response_obj, response_obj.clean_content
+                        )
+                        # self.bot.sent_last_message[str(message.channel.id)] = True
+                        # await log_message(response_obj)
 
     async def set_listen_only_mode_timer(self, channel_id):
         # Start the timer

--- a/cogs/pygbot.py
+++ b/cogs/pygbot.py
@@ -244,6 +244,11 @@ class ChatbotCog(commands.Cog, name="chatbot"):
         if self.current_task is not None and not self.current_task.done():
             # Cancelling previous task, add last message to the history
             await self.chatbot.add_history(name, str(channel_id), self.last_message)
+
+            # If the llm type is "koboldai", stop the generation from the API
+            if self.bot.llm._llm_type == "koboldai":
+                await self.bot.llm._stop()
+
             self.current_task.cancel()
 
         # Create new task and store in current_task

--- a/discordbot.py
+++ b/discordbot.py
@@ -243,10 +243,9 @@ async def on_ready():
     # Check if the endpoint is connected to koboldcpp
     if bot.llm._llm_type == "koboldai":
         bot.koboldcpp_version = bot.llm.check_version()
+        print(f"KoboldCPP Version: {bot.koboldcpp_version}")
     else:
         bot.koboldcpp_version = 0.0
-
-    print(f"KoboldCPP Version: {bot.koboldcpp_version}")
 
 
 # COG LOADER

--- a/discordbot.py
+++ b/discordbot.py
@@ -240,6 +240,12 @@ async def on_ready():
                 "\n\n\n\nERROR: Unable to retrieve channel from .env \nPlease make sure you're using a valid channel ID, not a server ID."
             )
 
+    # Check if the endpoint is connected to koboldcpp
+    if bot.llm._llm_type == "koboldai":
+        bot.koboldcpp_version = bot.llm.check_version()
+    else:
+        bot.koboldcpp_version = 0.0
+
 
 # COG LOADER
 async def load_cogs() -> None:

--- a/discordbot.py
+++ b/discordbot.py
@@ -6,7 +6,8 @@ from PIL import Image
 from pathlib import Path
 import base64
 from helpers.textgen import TextGen
-from langchain.llms import KoboldApiLLM, OpenAI
+from helpers.koboldai import KoboldApiLLM
+from langchain.llms import OpenAI
 from discord import app_commands
 from discord.ext import commands
 from discord.ext.commands import Bot

--- a/discordbot.py
+++ b/discordbot.py
@@ -246,6 +246,8 @@ async def on_ready():
     else:
         bot.koboldcpp_version = 0.0
 
+    print(f"KoboldCPP Version: {bot.koboldcpp_version}")
+
 
 # COG LOADER
 async def load_cogs() -> None:

--- a/helpers/koboldai.py
+++ b/helpers/koboldai.py
@@ -1,0 +1,264 @@
+import logging
+from typing import Any, Dict, List, Optional
+
+import requests
+import asyncio
+import aiohttp
+
+from langchain.callbacks.manager import  (
+    AsyncCallbackManagerForLLMRun,
+    CallbackManagerForLLMRun,
+)
+from langchain.llms.base import LLM
+
+logger = logging.getLogger(__name__)
+
+
+def clean_url(url: str) -> str:
+    """Remove trailing slash and /api from url if present."""
+    if url.endswith("/api"):
+        return url[:-4]
+    elif url.endswith("/"):
+        return url[:-1]
+    else:
+        return url
+
+
+class KoboldApiLLM(LLM):
+    """Kobold API language model.
+
+    It includes several fields that can be used to control the text generation process.
+
+    To use this class, instantiate it with the required parameters and call it with a
+    prompt to generate text. For example:
+
+        kobold = KoboldApiLLM(endpoint="http://localhost:5000")
+        result = kobold("Write a story about a dragon.")
+
+    This will send a POST request to the Kobold API with the provided prompt and
+    generate text.
+    """
+
+    endpoint: str
+    """The API endpoint to use for generating text."""
+
+    use_story: Optional[bool] = False
+    """ Whether or not to use the story from the KoboldAI GUI when generating text. """
+
+    use_authors_note: Optional[bool] = False
+    """Whether to use the author's note from the KoboldAI GUI when generating text.
+    
+    This has no effect unless use_story is also enabled.
+    """
+
+    use_world_info: Optional[bool] = False
+    """Whether to use the world info from the KoboldAI GUI when generating text."""
+
+    use_memory: Optional[bool] = False
+    """Whether to use the memory from the KoboldAI GUI when generating text."""
+
+    max_context_length: Optional[int] = 1600
+    """Maximum number of tokens to send to the model.
+    
+    minimum: 1
+    """
+
+    max_length: Optional[int] = 80
+    """Number of tokens to generate.
+    
+    maximum: 512
+    minimum: 1
+    """
+
+    rep_pen: Optional[float] = 1.12
+    """Base repetition penalty value.
+    
+    minimum: 1
+    """
+
+    rep_pen_range: Optional[int] = 1024
+    """Repetition penalty range.
+    
+    minimum: 0
+    """
+
+    rep_pen_slope: Optional[float] = 0.9
+    """Repetition penalty slope.
+    
+    minimum: 0
+    """
+
+    temperature: Optional[float] = 0.6
+    """Temperature value.
+    
+    exclusiveMinimum: 0
+    """
+
+    tfs: Optional[float] = 0.9
+    """Tail free sampling value.
+    
+    maximum: 1
+    minimum: 0
+    """
+
+    top_a: Optional[float] = 0.9
+    """Top-a sampling value.
+    
+    minimum: 0
+    """
+
+    top_p: Optional[float] = 0.95
+    """Top-p sampling value.
+    
+    maximum: 1
+    minimum: 0
+    """
+
+    top_k: Optional[int] = 0
+    """Top-k sampling value.
+    
+    minimum: 0
+    """
+
+    typical: Optional[float] = 0.5
+    """Typical sampling value.
+    
+    maximum: 1
+    minimum: 0
+    """
+
+    @property
+    def _llm_type(self) -> str:
+        return "koboldai"
+
+    # Define a helper method to generate the data dict
+    def _get_parameters(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None) -> Dict[str, Any]:
+        """Get the parameters to send to the API."""
+        data: Dict[str, Any] = {
+            "prompt": prompt,
+            "use_story": self.use_story,
+            "use_authors_note": self.use_authors_note,
+            "use_world_info": self.use_world_info,
+            "use_memory": self.use_memory,
+            "max_context_length": self.max_context_length,
+            "max_length": self.max_length,
+            "rep_pen": self.rep_pen,
+            "rep_pen_range": self.rep_pen_range,
+            "rep_pen_slope": self.rep_pen_slope,
+            "temperature": self.temperature,
+            "tfs": self.tfs,
+            "top_a": self.top_a,
+            "top_p": self.top_p,
+            "top_k": self.top_k,
+            "typical": self.typical,
+        }
+
+        if stop:
+            data["stop_sequence"] = stop
+
+        return data
+
+    def _call(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Call the API and return the output.
+
+        Args:
+            prompt: The prompt to use for generation.
+            stop: A list of strings to stop generation when encountered.
+
+        Returns:
+            The generated text.
+
+        Example:
+            .. code-block:: python
+
+                from langchain.llms import KoboldApiLLM
+
+                llm = KoboldApiLLM(endpoint="http://localhost:5000")
+                llm("Write a story about dragons.")
+        """
+        data = self._get_parameters(prompt, stop)
+
+        response = requests.post(
+            f"{clean_url(self.endpoint)}/api/v1/generate", json=data
+        )
+
+        response.raise_for_status()
+        json_response = response.json()
+
+        if (
+            "results" in json_response
+            and len(json_response["results"]) > 0
+            and "text" in json_response["results"][0]
+        ):
+            text = json_response["results"][0]["text"].strip()
+
+            if stop is not None:
+                for sequence in stop:
+                    if text.endswith(sequence):
+                        text = text[: -len(sequence)].rstrip()
+
+            return text
+        else:
+            raise ValueError(
+                f"Unexpected response format from Kobold API:  {json_response}"
+            )
+    
+    async def _acall(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Call the API and return the output.
+
+        Args:
+            prompt: The prompt to use for generation.
+            stop: A list of strings to stop generation when encountered.
+
+        Returns:
+            The generated text.
+
+        Example:
+            .. code-block:: python
+
+                from langchain.llms import KoboldApiLLM
+
+                llm = KoboldApiLLM(endpoint="http://localhost:5000")
+                llm("Write a story about dragons.")
+        """
+        data = self._get_parameters(prompt, stop)
+
+         # Use aiohttp to call KoboldAI API asynchronously to prevent blocking
+        async with aiohttp.ClientSession() as session:
+            async with session.post(f"{clean_url(self.endpoint)}/api/v1/generate", json=data) as response:
+
+                response.raise_for_status()
+                json_response = await response.json()
+
+                if (
+                    "results" in json_response
+                    and len(json_response["results"]) > 0
+                    and "text" in json_response["results"][0]
+                ):
+                    text = json_response["results"][0]["text"].strip()
+
+                    if stop is not None:
+                        for sequence in stop:
+                            if text.endswith(sequence):
+                                text = text[: -len(sequence)].rstrip()
+
+                    return text
+                else:
+                    raise ValueError(
+                        f"Unexpected response format from Kobold API:  {json_response}"
+                    )

--- a/helpers/koboldai.py
+++ b/helpers/koboldai.py
@@ -212,6 +212,7 @@ class KoboldApiLLM(LLM):
                 f"Unexpected response format from Kobold API:  {json_response}"
             )
     
+    # New function to call KoboldAI API asynchronously
     async def _acall(
         self,
         prompt: str,
@@ -262,3 +263,17 @@ class KoboldApiLLM(LLM):
                     raise ValueError(
                         f"Unexpected response format from Kobold API:  {json_response}"
                     )
+
+    async def _stop(self):
+        """Send abort request to stop ongoing AI generation.
+        This only applies to koboldcpp. Official KoboldAI API does not support this.
+        """
+        
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(f"{clean_url(self.endpoint)}/api/extra/abort") as response:
+                    if response.status == 200:
+                        print("Successfully aborted AI generation.")
+
+        except Exception as e:
+            print(f"Error aborting AI generation: {e}")

--- a/helpers/textgen.py
+++ b/helpers/textgen.py
@@ -271,6 +271,9 @@ class TextGen(LLM):
             async with aiohttp.ClientSession() as session:
                 url = f"{self.model_url}/api/v1/generate"
                 params = self._get_parameters(stop)
+                params["stopping_strings"] = params.pop(
+                    "stop"
+                )  # Rename 'stop' to 'stopping_strings'
                 request = params.copy()
                 request["prompt"] = prompt
                 #response = requests.post(url, json=request)

--- a/helpers/textgen.py
+++ b/helpers/textgen.py
@@ -3,8 +3,13 @@ import logging
 from typing import Any, Dict, Iterator, List, Optional
 
 import requests
+import asyncio
+import aiohttp
 
-from langchain.callbacks.manager import CallbackManagerForLLMRun
+from langchain.callbacks.manager import  (
+    AsyncCallbackManagerForLLMRun,
+    CallbackManagerForLLMRun,
+)
 from langchain.llms.base import LLM
 from langchain.pydantic_v1 import Field
 from langchain.schema.output import GenerationChunk
@@ -217,7 +222,7 @@ class TextGen(LLM):
             print(params["stopping_strings"])  # TODO: Remove this line
             request = params.copy()
             request["prompt"] = prompt
-            print(request)  # TODO: Remove this line
+            #print(request)  # TODO: Remove this line
             response = requests.post(url, json=request)
 
             if response.status_code == 200:
@@ -226,6 +231,56 @@ class TextGen(LLM):
             else:
                 print(f"ERROR: response: {response}")
                 result = ""
+
+        return result
+
+    # Implement _acall function from LangChain example github
+    async def _acall(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Call the textgen web API and return the output.
+
+        Args:
+            prompt: The prompt to use for generation.
+            stop: A list of strings to stop generation when encountered.
+
+        Returns:
+            The generated text.
+
+        Example:
+            .. code-block:: python
+
+                from langchain.llms import TextGen
+                llm = TextGen(model_url="http://localhost:5000")
+                llm("Write a story about llamas.")
+        """
+        if self.streaming:
+            combined_text_output = ""
+            async for chunk in self._astream(
+                prompt=prompt, stop=stop, run_manager=run_manager, **kwargs
+            ):
+                combined_text_output += chunk.text
+            result = combined_text_output
+
+        else:
+            # Use aiohttp to call textgen API asynchronously to prevent blocking
+            async with aiohttp.ClientSession() as session:
+                url = f"{self.model_url}/api/v1/generate"
+                params = self._get_parameters(stop)
+                request = params.copy()
+                request["prompt"] = prompt
+                #response = requests.post(url, json=request)
+
+                async with session.post(url, json=request) as response:
+                    if response.status == 200:
+                        result = (await response.json())["results"][0]["text"]
+                    else:
+                        print(f"ERROR: response: {response}")
+                        result = ""
 
         return result
 


### PR DESCRIPTION
Currently, the bot will reply to multiple people all at once, which could be unintended effect, especially when you have multiple people in the text channel. (assuming ALWAYS_REPLY is set to true)

For example:
![image](https://github.com/ausboss/PygDiscordBot/assets/17120382/13c7de37-c063-45c0-97ad-b05c08f3de99)

This PR "should" fix this problem, where the bot will only reply once. The current AI model nowadays are pretty great at summarize what happened in the chat room (evident by just using listen-only mode).

The intended way for bot to reply (note that I sent replies to the bot 2 times instead of one):
![image](https://github.com/ausboss/PygDiscordBot/assets/17120382/7fb6f999-30b9-4364-920e-99873bcb2cb3)

### To-do checklist
- [x] Implement task creation and cancellation from asyncio library
- [x] Use aiohttp to create POST session instead of usual POST request to prevent blocking
- [x] Resolved memory issues (bot can't see 2nd last reply)
- [x] TextGen compatible (though it doesn't prevent server from stopping the generation because of API limitation)
- [x] KoboldAI API compatible
- [x] Koboldcpp compatible (generate unique key to API to support multiple channel ID)
- [x] Multiple channel ID support

**Currently, this PR is untested for multiple channel IDs, so if you want to test this implementation, you can pull my main repo instead.**